### PR TITLE
feat: add brand icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,26 @@ import { TrendingDown } from "./icons/trending-down";
 import { TrendingUp } from "./icons/trending-up";
 import { FolderKanban } from "./icons/folder-kanban";
 import { PanelsTopLeft } from "./icons/panels-top-left";
+import { Bitcoin } from "./icons/bitcoin";
+import { Chrome } from "./icons/chrome";
+import { Codepen } from "./icons/codepen";
+import { Codesandbox } from "./icons/codesandbox";
+import { Dribbble } from "./icons/dribbble";
+import { Facebook } from "./icons/facebook";
+import { Figma } from "./icons/figma";
+import { Framer } from "./icons/framer";
+import { Github } from "./icons/github";
+import { Gitlab } from "./icons/gitlab";
+import { Hexagon } from "./icons/hexagon";
+import { Instagram } from "./icons/instagram";
+import { Linkedin } from "./icons/linkedin";
+import { Pocket } from "./icons/pocket";
+import { Slack } from "./icons/slack";
+import { Target } from "./icons/target";
+import { Trello } from "./icons/trello";
+import { Twitch } from "./icons/twitch";
+import { Twitter } from "./icons/twitter";
+import { Youtube } from "./icons/youtube";
 
 const Icons = [
   Activity,
@@ -343,6 +363,26 @@ const Icons = [
   TrendingUp,
   FolderKanban,
   PanelsTopLeft,
+  Bitcoin,
+  Chrome,
+  Codepen,
+  Codesandbox,
+  Dribbble,
+  Facebook,
+  Figma,
+  Framer,
+  Github,
+  Gitlab,
+  Hexagon,
+  Instagram,
+  Linkedin,
+  Pocket,
+  Slack,
+  Target,
+  Trello,
+  Twitch,
+  Twitter,
+  Youtube,
 ];
 
 function App() {

--- a/src/icons/bitcoin.tsx
+++ b/src/icons/bitcoin.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Bitcoin: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [
+        { transform: "translate(0, 0)", rotate: "0deg" },
+        { transform: "translate(0, -5px)", rotate: "-15deg" },
+        { transform: "translate(0, 0)", rotate: "0deg" },
+        { transform: "translate(0, -5px)", rotate: "-15deg" },
+        { transform: "translate(0, 0)", rotate: "0deg" },
+      ],
+      {
+        duration: 800,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M11.767 19.089c4.924.868 6.14-6.025 1.216-6.894m-1.216 6.894L5.86 18.047m5.908 1.042-.347 1.97m1.563-8.864c4.924.869 6.14-6.025 1.215-6.893m-1.215 6.893-3.94-.694m5.155-6.2L8.29 4.26m5.908 1.042.348-1.97M7.48 20.364l3.126-17.727" />
+    </svg>
+  );
+};

--- a/src/icons/chrome.tsx
+++ b/src/icons/chrome.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Chrome: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate([{ rotate: "0deg" }, { rotate: "360deg" }], {
+      duration: 800,
+      iterations: 1,
+      fill: "forwards",
+      easing: "ease-in-out",
+    });
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <circle cx="12" cy="12" r="4" />
+      <line x1="21.17" x2="12" y1="8" y2="8" />
+      <line x1="3.95" x2="8.54" y1="6.06" y2="14" />
+      <line x1="10.88" x2="15.46" y1="21.94" y2="14" />
+    </svg>
+  );
+};

--- a/src/icons/codepen.tsx
+++ b/src/icons/codepen.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Codepen: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2" />
+      <line x1="12" x2="12" y1="22" y2="15.5" />
+      <polyline points="22 8.5 12 15.5 2 8.5" />
+      <polyline points="2 15.5 12 8.5 22 15.5" />
+      <line x1="12" x2="12" y1="2" y2="8.5" />
+    </svg>
+  );
+};

--- a/src/icons/codesandbox.tsx
+++ b/src/icons/codesandbox.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Codesandbox: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+      <polyline points="7.5 4.21 12 6.81 16.5 4.21" />
+      <polyline points="7.5 19.79 7.5 14.6 3 12" />
+      <polyline points="21 12 16.5 14.6 16.5 19.79" />
+      <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+      <line x1="12" x2="12" y1="22.08" y2="12" />
+    </svg>
+  );
+};

--- a/src/icons/dribbble.tsx
+++ b/src/icons/dribbble.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Dribbble: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate([{ rotate: "0deg" }, { rotate: "360deg" }], {
+      duration: 800,
+      iterations: 1,
+      fill: "forwards",
+      easing: "ease-in-out",
+    });
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M19.13 5.09C15.22 9.14 10 10.44 2.25 10.94" />
+      <path d="M21.75 12.84c-6.62-1.41-12.14 1-16.38 6.32" />
+      <path d="M8.56 2.75c4.37 6 6 9.42 8 17.72" />
+    </svg>
+  );
+};

--- a/src/icons/facebook.tsx
+++ b/src/icons/facebook.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Facebook: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z" />
+    </svg>
+  );
+};

--- a/src/icons/figma.tsx
+++ b/src/icons/figma.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Figma: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M5 5.5A3.5 3.5 0 0 1 8.5 2H12v7H8.5A3.5 3.5 0 0 1 5 5.5z" />
+      <path d="M12 2h3.5a3.5 3.5 0 1 1 0 7H12V2z" />
+      <path d="M12 12.5a3.5 3.5 0 1 1 7 0 3.5 3.5 0 1 1-7 0z" />
+      <path d="M5 19.5A3.5 3.5 0 0 1 8.5 16H12v3.5a3.5 3.5 0 1 1-7 0z" />
+      <path d="M5 12.5A3.5 3.5 0 0 1 8.5 9H12v7H8.5A3.5 3.5 0 0 1 5 12.5z" />
+    </svg>
+  );
+};

--- a/src/icons/framer.tsx
+++ b/src/icons/framer.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Framer: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M5 16V9h14V2H5l14 14h-7m-7 0 7 7v-7m-7 0h7" />
+    </svg>
+  );
+};

--- a/src/icons/github.tsx
+++ b/src/icons/github.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Github: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+  const tailRef = useRef<SVGPathElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+
+    tailRef.current?.animate(
+      [
+        { transform: "translate(0, 0)" },
+        { transform: "translate(1px, -2px)" },
+        { transform: "translate(0, 0)" },
+        { transform: "translate(1px, -2px)" },
+        { transform: "translate(0, 0)" },
+      ],
+      {
+        duration: 800,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" ref={tailRef} />
+    </svg>
+  );
+};

--- a/src/icons/gitlab.tsx
+++ b/src/icons/gitlab.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Gitlab: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="m22 13.29-3.33-10a.42.42 0 0 0-.14-.18.38.38 0 0 0-.22-.11.39.39 0 0 0-.23.07.42.42 0 0 0-.14.18l-2.26 6.67H8.32L6.1 3.26a.42.42 0 0 0-.1-.18.38.38 0 0 0-.26-.08.39.39 0 0 0-.23.07.42.42 0 0 0-.14.18L2 13.29a.74.74 0 0 0 .27.83L12 21l9.69-6.88a.71.71 0 0 0 .31-.83Z" />
+    </svg>
+  );
+};

--- a/src/icons/hexagon.tsx
+++ b/src/icons/hexagon.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Hexagon: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+    </svg>
+  );
+};

--- a/src/icons/instagram.tsx
+++ b/src/icons/instagram.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Instagram: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+  const dotRef = useRef<SVGLineElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+
+    dotRef.current?.animate(
+      [
+        { transform: "translate(0, 0)" },
+        { transform: "translate(-2px, 0)" },
+        { transform: "translate(0, 0)" },
+        { transform: "translate(-2px, 0)" },
+        { transform: "translate(0, 0)" },
+      ],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <rect width="20" height="20" x="2" y="2" rx="5" ry="5" />
+      <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
+      <line x1="17.5" x2="17.51" y1="6.5" y2="6.5" ref={dotRef} />
+    </svg>
+  );
+};

--- a/src/icons/linkedin.tsx
+++ b/src/icons/linkedin.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Linkedin: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
+      <rect width="4" height="12" x="2" y="9" />
+      <circle cx="4" cy="4" r="2" />
+    </svg>
+  );
+};

--- a/src/icons/pocket.tsx
+++ b/src/icons/pocket.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Pocket: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+  const polylineRef = useRef<SVGPolylineElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+
+    polylineRef.current?.animate(
+      [{ transform: "translateY(-8px)" }, { transform: "translateY(0)" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M4 3h16a2 2 0 0 1 2 2v6a10 10 0 0 1-10 10A10 10 0 0 1 2 11V5a2 2 0 0 1 2-2z" />
+      <polyline points="8 10 12 14 16 10" ref={polylineRef} />
+    </svg>
+  );
+};

--- a/src/icons/slack.tsx
+++ b/src/icons/slack.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Slack: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <rect width="3" height="8" x="13" y="2" rx="1.5" />
+      <path d="M19 8.5V10h1.5A1.5 1.5 0 1 0 19 8.5" />
+      <rect width="3" height="8" x="8" y="14" rx="1.5" />
+      <path d="M5 15.5V14H3.5A1.5 1.5 0 1 0 5 15.5" />
+      <rect width="8" height="3" x="14" y="13" rx="1.5" />
+      <path d="M15.5 19H14v1.5a1.5 1.5 0 1 0 1.5-1.5" />
+      <rect width="8" height="3" x="2" y="8" rx="1.5" />
+      <path d="M8.5 5H10V3.5A1.5 1.5 0 1 0 8.5 5" />
+    </svg>
+  );
+};

--- a/src/icons/target.tsx
+++ b/src/icons/target.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Target: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+  const polylineRef = useRef<SVGPolylineElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+
+    polylineRef.current?.animate(
+      [{ transform: "translateY(-8px)" }, { transform: "translateY(0)" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <circle cx="12" cy="12" r="6" />
+      <circle cx="12" cy="12" r="2" />
+    </svg>
+  );
+};

--- a/src/icons/trello.tsx
+++ b/src/icons/trello.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Trello: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+      <rect width="3" height="9" x="7" y="7" />
+      <rect width="3" height="5" x="14" y="7" />
+    </svg>
+  );
+};

--- a/src/icons/twitch.tsx
+++ b/src/icons/twitch.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Twitch: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M21 2H3v16h5v4l4-4h5l4-4V2zm-10 9V7m5 4V7" />
+    </svg>
+  );
+};

--- a/src/icons/twitter.tsx
+++ b/src/icons/twitter.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Twitter: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z" />
+    </svg>
+  );
+};

--- a/src/icons/youtube.tsx
+++ b/src/icons/youtube.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+
+import type { IconProps } from "./icon.types";
+
+export const Youtube: React.FC<IconProps> = ({
+  "data-hovered": hovered,
+  ...props
+}) => {
+  const baseRef = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    if (!hovered) return;
+
+    baseRef.current?.animate(
+      [{ strokeDasharray: "0, 100" }, { strokeDasharray: "100, 0" }],
+      {
+        duration: 600,
+        iterations: 1,
+        fill: "forwards",
+        easing: "ease-in-out",
+      }
+    );
+  }, [hovered]);
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      ref={baseRef}
+      {...props}
+    >
+      <path d="M2.5 17a24.12 24.12 0 0 1 0-10 2 2 0 0 1 1.4-1.4 49.56 49.56 0 0 1 16.2 0A2 2 0 0 1 21.5 7a24.12 24.12 0 0 1 0 10 2 2 0 0 1-1.4 1.4 49.55 49.55 0 0 1-16.2 0A2 2 0 0 1 2.5 17" />
+      <path d="m10 15 5-3-5-3z" />
+    </svg>
+  );
+};


### PR DESCRIPTION
### New Icons

* **Icons**
Added new icons such as `Bitcoin`, `Chrome`, `Codepen`, `Codesandbox`, `Dribbble`, `Facebook`, `Figma`, `Framer`, `Github`, `Gitlab`, `Hexagon`, `Instagram`, `Linkedin`, `Pocket`, `Slack`, `Target`, `Trello`, `Twitch`, `Twitter`, and `Youtube`
 